### PR TITLE
Fix use after free() and double free()

### DIFF
--- a/sem_init.c
+++ b/sem_init.c
@@ -126,7 +126,6 @@ sem_init (sem_t * sem, int pshared, unsigned int value)
 
 	  if (0 == s->sem)
 	    {
-	      free (s);
 	      (void) pthread_mutex_destroy(&s->lock);
 	      result = ENOSPC;
 	    }


### PR DESCRIPTION
`free()` is called afterwards anyway. If control passes to this branch the original code would first have "use after free" and then the second `free()` would run.