### PR TITLE
Fixed a bunch of compiler warnings revealed by /W 4.

### DIFF
--- a/implement.h
+++ b/implement.h
@@ -216,6 +216,12 @@ typedef struct ptw32_mcs_node_t_*    ptw32_mcs_lock_t;
 typedef struct ptw32_robust_node_t_  ptw32_robust_node_t;
 typedef struct ptw32_thread_t_       ptw32_thread_t;
 
+#ifdef _MSC_VER
+  // Suppress warnings about padding changes due to alignment.
+  #pragma warning(push)
+  #pragma warning(disable: 4324)
+#endif // _MSC_VER
+
 struct ptw32_thread_t_
 {
   unsigned __int64 seqNumber;	/* Process-unique thread sequence number */
@@ -256,6 +262,10 @@ struct ptw32_thread_t_
 #endif
   size_t align;			/* Force alignment if this struct is packed */
 };
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif // _MSC_VER
 
 
 /*

--- a/pthread_attr_getaffinity_np.c
+++ b/pthread_attr_getaffinity_np.c
@@ -48,6 +48,7 @@
 int
 pthread_attr_getaffinity_np (const pthread_attr_t * attr, size_t cpusetsize, cpu_set_t * cpuset)
 {
+  (void)cpusetsize;
   if (ptw32_is_attr (attr) != 0 || cpuset == NULL)
     {
       return EINVAL;

--- a/pthread_attr_getname_np.c
+++ b/pthread_attr_getname_np.c
@@ -50,7 +50,11 @@ pthread_attr_getname_np(pthread_attr_t * attr, char *name, int len)
 # pragma warning(suppress:4996)
   strncpy(name, (*attr)->thrname, len - 1);
   (*attr)->thrname[len - 1] = '\0';
-#endif
+#else // _MSVCRT_
+  (void)attr;
+  (void)name;
+  (void)len;
+#endif // _MSVCRT_
 
   return 0;
 }

--- a/pthread_attr_setaffinity_np.c
+++ b/pthread_attr_setaffinity_np.c
@@ -48,6 +48,7 @@
 int
 pthread_attr_setaffinity_np (pthread_attr_t * attr, size_t cpusetsize, const cpu_set_t * cpuset)
 {
+  (void)cpusetsize;
   if (ptw32_is_attr (attr) != 0 || cpuset == NULL)
     {
       return EINVAL;

--- a/pthread_attr_setstackaddr.c
+++ b/pthread_attr_setstackaddr.c
@@ -98,6 +98,8 @@ pthread_attr_setstackaddr (pthread_attr_t * attr, void *stackaddr)
 
 #else
 
+  (void)stackaddr;
+  (void)attr;
   return ENOSYS;
 
 #endif /* _POSIX_THREAD_ATTR_STACKADDR */

--- a/pthread_cancel.c
+++ b/pthread_cancel.c
@@ -56,7 +56,8 @@ ptw32_cancel_self (void)
 static void CALLBACK
 ptw32_cancel_callback (ULONG_PTR unused)
 {
-  ptw32_throw (PTW32_EPS_CANCEL);
+ (void)unused;
+ ptw32_throw (PTW32_EPS_CANCEL);
 
   /* Never reached */
 }
@@ -70,6 +71,8 @@ DWORD
 ptw32_RegisterCancellation (PAPCFUNC unused1, HANDLE threadH, DWORD unused2)
 {
   CONTEXT context;
+  (void)unused1;
+  (void)unused2;
 #ifndef ENABLE_WINRT
   context.ContextFlags = CONTEXT_CONTROL;
   GetThreadContext (threadH, &context);

--- a/pthread_kill.c
+++ b/pthread_kill.c
@@ -130,7 +130,7 @@ pthread_kill (pthread_t thread, int sig)
               tp->cancelState = PTHREAD_CANCEL_DISABLE;
               ptw32_mcs_lock_release(&stateLock);
 
-              result = TerminateThread(tp->threadH, (DWORD)(size_t)PTHREAD_CANCELED);
+              result = TerminateThread(tp->threadH, (DWORD)(intptr_t)PTHREAD_CANCELED);
               result = (result != 0) ? 0 : EINVAL;
 
               // Set exit to CANCELED (KILLED) when it hasn't been set already.

--- a/pthread_setaffinity.c
+++ b/pthread_setaffinity.c
@@ -98,6 +98,8 @@ pthread_setaffinity_np (pthread_t thread, size_t cpusetsize,
   ptw32_mcs_local_node_t node;
   cpu_set_t processCpuset;
 
+  (void)cpusetsize;
+
   ptw32_mcs_lock_acquire (&ptw32_thread_reuse_lock, &node);
 
   tp = (ptw32_thread_t *) thread.p;
@@ -202,6 +204,8 @@ pthread_getaffinity_np (pthread_t thread, size_t cpusetsize, cpu_set_t *cpuset)
   int result = 0;
   ptw32_thread_t * tp;
   ptw32_mcs_local_node_t node;
+
+  (void)cpusetsize;
 
   ptw32_mcs_lock_acquire(&ptw32_thread_reuse_lock, &node);
 

--- a/pthread_timechange_handler_np.c
+++ b/pthread_timechange_handler_np.c
@@ -99,6 +99,8 @@ pthread_timechange_handler_np (void *arg)
   pthread_cond_t cv;
   ptw32_mcs_local_node_t node;
 
+  (void)arg;
+
   ptw32_mcs_lock_acquire(&ptw32_cond_list_lock, &node);
 
   cv = ptw32_cond_list_head;

--- a/ptw32_MCS_lock.c
+++ b/ptw32_MCS_lock.c
@@ -123,7 +123,7 @@ ptw32_mcs_flag_set (HANDLE * flag)
    *       when the above interlocked-compare-and-exchange
    *       is executed.
    */
-  if (((HANDLE)0 != e) && ((HANDLE)-1 != e))
+  if (((HANDLE)(intptr_t)0 != e) && ((HANDLE)(intptr_t)-1 != e))
     {
       /* another thread has already stored an event handle in the flag */
       SetEvent(e);

--- a/ptw32_throw.c
+++ b/ptw32_throw.c
@@ -103,12 +103,12 @@ ptw32_throw (DWORD exception)
       switch (exception)
         {
       	  case PTW32_EPS_CANCEL:
-      		exitCode = (unsigned int)(size_t) PTHREAD_CANCELED;
+      		exitCode = (unsigned int)(intptr_t) PTHREAD_CANCELED;
       		break;
       	  case PTW32_EPS_EXIT:
       		if (NULL != sp)
       		  {
-      			exitCode = (unsigned int)(size_t) sp->exitStatus;
+      			exitCode = (unsigned int)(intptr_t) sp->exitStatus;
       		  }
       		break;
         }

--- a/semaphore.h
+++ b/semaphore.h
@@ -83,7 +83,7 @@ typedef struct sem_t_ * sem_t;
  * returned on failure of sem_open(); (our implementation is a
  * stub, which will always return this).
  */
-#define SEM_FAILED  (sem_t *)(-1)
+#define SEM_FAILED  (sem_t *)(intptr_t)(-1)
 
 PTW32_BEGIN_C_DECLS
 


### PR DESCRIPTION
I'm transitioning my pthread-win32-using solution to more voluminous warnings.
This change compiles without warnings in debug/release in Visual Studios 2010, 2015, and 2017.